### PR TITLE
debug: add two benchmarks to show logging cost (do-not-merge)

### DIFF
--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -1,0 +1,28 @@
+package debug_test
+
+import (
+	"log"
+	"testing"
+
+	"github.com/relab/raft/debug"
+)
+
+func BenchmarkDebugPrintfOff(b *testing.B) {
+	debug.SetVerbosity(debug.OFF)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		debug.Debugf("something happend (%d)", 42)
+	}
+}
+
+func BenchmarkLogPrintfOffUsingBool(b *testing.B) {
+	loggingEnabled := false
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if loggingEnabled {
+			log.Printf("something happend (%d)", 42)
+		}
+	}
+}


### PR DESCRIPTION
If absolute (and not relative) performance numbers matters for your benchmarks,
then it might be worth investigating the impact the current debug package
(even when turned off).

The debug package is convenient, but even with SetVerbosity to OFF, every log
call allocates. It is on my laptop almost 2 orders of magnitude slower than a
log call guarded by a boolean:

```
BenchmarkDebugPrintfOff-4               30000000                42.5 ns/op             8 B/op          1 allocs/op
BenchmarkLogPrintfOffUsingBool-4        2000000000               0.37 ns/op            0 B/op          0 allocs/op
```

This is because all the logs functions takes an empty interface as a parameter,
and using a string as the interface argument causes an allocation (the data
part of an interface can store 8 bytes, an string header is 16 bytes). See e.g.
for more info: https://youtu.be/xxDZuPEgbBU?t=2070 

I'm not sure all of this matters when running a complete system benchmark. 